### PR TITLE
RTT & Group-ID-based publish

### DIFF
--- a/broke-broker/src/main/java/org/dsngroup/broke/broker/channel/handler/ClientProber.java
+++ b/broke-broker/src/main/java/org/dsngroup/broke/broker/channel/handler/ClientProber.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2017 original authors and authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dsngroup.broke.broker.channel.handler;
+
+import io.netty.channel.Channel;
+import io.netty.util.concurrent.ScheduledFuture;
+import org.dsngroup.broke.broker.storage.PingRequests;
+import org.dsngroup.broke.broker.storage.ServerSession;
+import org.dsngroup.broke.protocol.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayDeque;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class ClientProber {
+
+    private AtomicInteger pingReqPacketIdGenerator;
+
+    private ScheduledFuture pingReqScheduleFuture;
+
+    private RttStatistics rttStatistics;
+
+    private PingRequests pingRequests;
+
+    /**
+     * Getter for current round-trip time
+     * */
+    public double getRttAvg() {
+        return rttStatistics.getRttAvg();
+    }
+
+    private void setPingReq(int packetId) {
+        pingRequests.setPingReq(packetId, System.nanoTime());
+    }
+
+    void setPingResp(int packetId) {
+        long sendTime = pingRequests.getPingReq(packetId);
+        if (sendTime != -1) {
+            double newRtt = (System.nanoTime() - sendTime)/1e6;
+            rttStatistics.updateRttStatistics(newRtt);
+        }
+    }
+
+    /**
+     * Called in the processConnect(). When the client makes the connection successfully, schedule the PING message.
+     * */
+    void schedulePingReq(Channel channel, ServerSession serverSession) {
+        pingReqScheduleFuture = channel.eventLoop().scheduleAtFixedRate(
+                new Runnable(){
+                    @Override
+                    public void run(){
+
+                        int packetId = pingReqPacketIdGenerator.getAndIncrement();
+                        MqttFixedHeader mqttFixedHeader =
+                                new MqttFixedHeader(MqttMessageType.PINGREQ, false, MqttQoS.AT_MOST_ONCE, false, 0);
+                        MqttMessageIdVariableHeader mqttMessageIdVariableHeader =
+                                MqttMessageIdVariableHeader.from(packetId);
+                        MqttPingReqMessage mqttPingReqMessage =
+                                new MqttPingReqMessage(mqttFixedHeader, mqttMessageIdVariableHeader);
+                        // Set the PINGREQ's sendTime
+                        setPingReq(packetId);
+                        channel.writeAndFlush(mqttPingReqMessage);
+                    }
+                }, 3, 3, TimeUnit.SECONDS);
+    }
+
+    void cancelPingReq() {
+        // Stop the PINGREQ schedule
+        pingReqScheduleFuture.cancel(false);
+    }
+
+    ClientProber() {
+        this.pingReqPacketIdGenerator = new AtomicInteger();
+        this.pingReqPacketIdGenerator.getAndIncrement();
+        this.pingRequests = new PingRequests();
+        this.rttStatistics = new RttStatistics(1000);
+    }
+}
+
+class RttStatistics {
+
+    // Queue that stores history RTTs for statistic calculation.
+    private ArrayDeque<Double> rttQueue;
+
+    private final int maxRttNumber;
+
+    // Average of RTTs
+    private double rttAvg;
+
+    // Standard deviation of RTTs
+    private double rttDev;
+
+    private static final Logger logger = LoggerFactory.getLogger(RttStatistics.class);
+
+    // TODO: synchronize may be unnecessary?
+    synchronized double getRttAvg() {
+        return rttAvg;
+    }
+
+    // TODO: synchronize may be unnecessary?
+    synchronized void updateRttStatistics(double newRtt) {
+        logger.debug("Rtt numbers: "+rttQueue.size()+" Rtt New: "+newRtt+" RTT Avg "+rttAvg+" Rtt StdDev: "+rttDev);
+        // Check validation only when the collected number of RTT is larger than half of the maxRttNumber
+        if(rttQueue.size()>maxRttNumber/2 && !isValidRtt(newRtt)) {
+            return;
+        }
+        rttQueue.offer(newRtt);
+        while(rttQueue.size()>maxRttNumber) {
+            rttQueue.poll();
+        }
+
+        // Update average
+        double sum = 0;
+        for(double rtt: rttQueue) {
+            sum+=rtt;
+        }
+        rttAvg = sum/rttQueue.size();
+
+        // Update rttDev;
+        double rttDiffSquareSum = 0;
+        for(double rtt: rttQueue) {
+            rttDiffSquareSum += Math.pow(rtt-rttAvg,2);
+        }
+        rttDev = Math.sqrt(rttDiffSquareSum/rttQueue.size());
+    }
+
+    private boolean isValidRtt(double newRtt) {
+        // A valid RTT should be in 2 standard deviations to the RTT average.
+        return Math.abs(newRtt-rttAvg)<=2*rttDev;
+    }
+
+    RttStatistics(int maxRttNumber) {
+        this.maxRttNumber = maxRttNumber;
+        this.rttQueue = new ArrayDeque<>();
+    }
+
+}

--- a/broke-broker/src/main/java/org/dsngroup/broke/broker/channel/handler/MessagePublisher.java
+++ b/broke-broker/src/main/java/org/dsngroup/broke/broker/channel/handler/MessagePublisher.java
@@ -67,8 +67,9 @@ public class MessagePublisher {
                 logger.error("Inactive channel");
             }
         } catch (Exception e) {
-
             logger.error(e.getMessage());
+            // TODO: delete this
+            logger.error(e.getStackTrace().toString());
         }
 
     }

--- a/broke-broker/src/main/java/org/dsngroup/broke/broker/channel/handler/MqttMessageHandler.java
+++ b/broke-broker/src/main/java/org/dsngroup/broke/broker/channel/handler/MqttMessageHandler.java
@@ -16,8 +16,11 @@
 
 package org.dsngroup.broke.broker.channel.handler;
 
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.util.ReferenceCountUtil;
 import org.dsngroup.broke.protocol.*;
 import org.dsngroup.broke.broker.ServerContext;
 import org.slf4j.Logger;
@@ -40,37 +43,49 @@ public class MqttMessageHandler extends ChannelInboundHandlerAdapter{
             switch (mqttMessage.fixedHeader().messageType()) {
                 case CONNECT:
                     protocolProcessor.processConnect(ctx.channel(), (MqttConnectMessage) mqttMessage);
-                    logger.info("[MqttMessageHandler] CONNECT");
+                    logger.debug("[MqttMessageHandler] CONNECT");
+                    ReferenceCountUtil.release(msg);
                     break;
                 case PUBLISH:
                     protocolProcessor.processPublish(ctx, (MqttPublishMessage) mqttMessage);
-                    logger.info("[MqttMessageHandler] PUBLISH");
+                    logger.debug("[MqttMessageHandler] PUBLISH");
                     break;
                 case SUBSCRIBE:
-                    logger.info("[MqttMessageHandler] SUBSCRIBE");
+                    logger.debug("[MqttMessageHandler] SUBSCRIBE");
                     protocolProcessor.processSubscribe(ctx.channel(), (MqttSubscribeMessage) mqttMessage);
+                    ReferenceCountUtil.release(msg);
                     break;
                 case PINGRESP:
-                    logger.info("[MqttMessageHandler] PINGRESP");
+                    logger.debug("[MqttMessageHandler] PINGRESP");
                     protocolProcessor.processPingResp(ctx.channel(), (MqttPingRespMessage) mqttMessage);
+                    ReferenceCountUtil.release(msg);
                     break;
                 case DISCONNECT:
-                    protocolProcessor.processDisconnect();
-                    logger.info("[MqttMessageHandler] DISCONNECT");
-                    ctx.close();
+                    logger.debug("[MqttMessageHandler] DISCONNECT");
+                    protocolProcessor.processDisconnect(ctx.channel());
+                    ReferenceCountUtil.release(msg);
                     break;
                 default:
                     logger.error("invalid message: "+msg.toString());
             }
         } catch (NullPointerException e) {
             logger.error(e.getMessage());
+            // TODO: delete this
+            logger.error(e.getStackTrace().toString());
         }
 
     }
 
     @Override
     public void channelActive(ChannelHandlerContext ctx) {
-        // Initialization of channel handler
+        // Add close future: triggered when the channel is closed.
+        ChannelFuture closeFuture = ctx.channel().closeFuture();
+        closeFuture.addListener(new ChannelFutureListener() {
+            @Override
+            public void operationComplete(ChannelFuture future) throws Exception {
+                protocolProcessor.processDisconnect(ctx.channel());
+            }
+        });
     }
 
     public MqttMessageHandler(ServerContext serverContext) {

--- a/broke-broker/src/main/java/org/dsngroup/broke/broker/storage/PingRequests.java
+++ b/broke-broker/src/main/java/org/dsngroup/broke/broker/storage/PingRequests.java
@@ -53,8 +53,8 @@ public class PingRequests {
  * */
 class PingReq {
 
-    int packetId;
-    long sendTime;
+    private int packetId;
+    private long sendTime;
 
     synchronized long getPingReq(int packetId) {
         if(this.packetId == packetId)

--- a/broke-client/src/main/java/org/dsngroup/broke/client/BlockClient.java
+++ b/broke-client/src/main/java/org/dsngroup/broke/client/BlockClient.java
@@ -69,7 +69,8 @@ public class BlockClient {
 
         // Connect only when the channel is active
         if(targetServerChannel.isActive()) {
-            logger.info("[Client] Make connection, clientId: "+clientId);
+            // TODO: delete this
+            logger.debug("[Client] Make connection, clientId: "+clientId);
 
             // Create CONNECT message
             MqttFixedHeader mqttFixedHeader =
@@ -122,7 +123,8 @@ public class BlockClient {
                     new MqttPublishMessage(mqttFixedHeader, mqttPublishVariableHeader, publisherPayload)
             );
 
-            logger.info("[Publish] Topic: " + topic + " Payload: " + payload);
+            // TODO: publish statistics.
+            logger.debug("[Publish] Topic: " + topic + " Payload: " + payload);
         } else {
             logger.error("[Publish] Channel closed, cannot publish");
         }
@@ -231,6 +233,8 @@ public class BlockClient {
 
         } catch (Exception e) {
             logger.error(e.getMessage());
+            // TODO: delete this
+            logger.error(e.getStackTrace().toString());
         }
     }
 

--- a/broke-client/src/main/java/org/dsngroup/broke/client/channel/handler/MqttMessageHandler.java
+++ b/broke-client/src/main/java/org/dsngroup/broke/client/channel/handler/MqttMessageHandler.java
@@ -18,6 +18,7 @@ package org.dsngroup.broke.client.channel.handler;
 
 import io.netty.channel.*;
 
+import io.netty.util.ReferenceCountUtil;
 import org.dsngroup.broke.protocol.*;
 
 import org.slf4j.Logger;
@@ -61,9 +62,10 @@ public class MqttMessageHandler extends ChannelInboundHandlerAdapter {
 
         } catch (Exception e) {
             logger.error(e.getMessage());
+            logger.error(e.getStackTrace().toString());
         } finally {
             // The msg object is an reference counting object.
-            // ReferenceCountUtil.release(msg);
+            ReferenceCountUtil.release(msg);
         }
     }
 

--- a/broke-client/src/main/java/org/dsngroup/broke/client/channel/handler/ProtocolProcessor.java
+++ b/broke-client/src/main/java/org/dsngroup/broke/client/channel/handler/ProtocolProcessor.java
@@ -34,7 +34,8 @@ public class ProtocolProcessor {
      * */
     public void processConnAck(ChannelHandlerContext ctx, MqttConnAckMessage mqttConnAckMessage) throws Exception {
         if (mqttConnAckMessage.variableHeader().connectReturnCode() == MqttConnectReturnCode.CONNECTION_ACCEPTED) {
-            logger.info("[Connect] Connect to broker"+ctx.channel().remoteAddress());
+            // TODO: delete this
+            logger.debug("[Connect] Connect to broker"+ctx.channel().remoteAddress());
         } else {
             logger.error("[Connect] Connection denied, close the channel.");
             ctx.channel().close();
@@ -47,8 +48,8 @@ public class ProtocolProcessor {
      * @param mqttPublishMessage PUBLISH message from broker
      * */
     public void processPublish(ChannelHandlerContext ctx, MqttPublishMessage mqttPublishMessage) throws Exception {
-        // TODO: logger.debug
-        logger.info( "Topic: "+mqttPublishMessage.variableHeader().topicName()+
+        // TODO: delete this
+        logger.debug( "Topic: "+mqttPublishMessage.variableHeader().topicName()+
                 " Payload: "+mqttPublishMessage.payload().toString(StandardCharsets.UTF_8) );
         // TODO: return PUBACK
     }
@@ -61,7 +62,8 @@ public class ProtocolProcessor {
      * */
     public void processPubAck(ChannelHandlerContext ctx, MqttPubAckMessage mqttPubAckMessage) throws Exception {
         // TODO: remove message in client session's unacked message queue
-        logger.info("[PUBACK] Packet ID "+mqttPubAckMessage.variableHeader().messageId());
+        // TODO: delete this.
+        logger.debug("[PUBACK] Packet ID "+mqttPubAckMessage.variableHeader().messageId());
     }
 
     /**
@@ -70,8 +72,8 @@ public class ProtocolProcessor {
      * @param mqttSubAckMessage SUBACK message from broker
      * */
     public void processSubAck(ChannelHandlerContext ctx, MqttSubAckMessage mqttSubAckMessage) throws Exception {
-        // TODO: logger.debug
-        logger.info(mqttSubAckMessage.payload().grantedQoSLevels().get(0).toString());
+        // TODO: delete this.
+        logger.debug(mqttSubAckMessage.payload().grantedQoSLevels().get(0).toString());
     }
 
     /**

--- a/broke-sample/src/main/java/org/dsngroup/broke/MultiClient.java
+++ b/broke-sample/src/main/java/org/dsngroup/broke/MultiClient.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2017 original authors and authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dsngroup.broke;
+
+import org.dsngroup.broke.client.BlockClient;
+import org.dsngroup.broke.protocol.MqttQoS;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class MultiClient {
+    public static void main(String args[]) {
+
+        String serverAddress = args[0];
+        int serverPort = Integer.parseInt(args[1]);
+
+        int numOfClients = 100;
+
+        PublishClient[] publishClients = new PublishClient[numOfClients];
+        SubscribeClient[] subscribeClients = new SubscribeClient[numOfClients];
+
+        String topic = "Foo";
+        int sleepInterval = 500; // publish sleep interval
+        int groupId = 1; // Subscribe group ID
+
+        // Initialize subscribe clients
+        for(int i=0; i<subscribeClients.length; i++) {
+            subscribeClients[i] = new SubscribeClient(serverAddress, serverPort, topic, groupId);
+            subscribeClients[i].start();
+        }
+
+        // Initialize publish clients
+        for(int i=0; i<publishClients.length; i++) {
+            publishClients[i] = new PublishClient(serverAddress, serverPort, topic, sleepInterval);
+            publishClients[i].start();
+        }
+    }
+}
+
+class PublishClient extends Thread {
+
+    private BlockClient blockClient;
+
+    private static final Logger logger = LoggerFactory.getLogger(PublishClient.class);
+
+    private String topic;
+
+    private int sleepInterval;
+
+    @Override
+    public void run() {
+        try {
+            blockClient.connect(1, 0);
+            while(true) {
+                blockClient.publish(topic, MqttQoS.AT_LEAST_ONCE, 0, "Foo");
+                Thread.sleep(sleepInterval);
+            }
+        } catch(Exception e) {
+            logger.error(e.getMessage());
+            logger.error(e.getStackTrace().toString());
+        }
+
+    }
+
+    public PublishClient(String serverAddress, int serverPort, String topic, int sleepInterval) {
+        try {
+            this.blockClient = new BlockClient(serverAddress, serverPort);
+            this.topic = topic;
+            this.sleepInterval = sleepInterval;
+        } catch (Exception e){
+            logger.error(e.getMessage());
+            logger.error(e.getStackTrace().toString());
+        }
+
+    }
+}
+
+class SubscribeClient extends Thread {
+
+    private BlockClient blockClient;
+
+    private static final Logger logger = LoggerFactory.getLogger(SubscribeClient.class);
+
+    private String topicFilter;
+
+    private int groupId;
+
+    @Override
+    public void run() {
+        try {
+            blockClient.connect(1, 0);
+            blockClient.subscribe(topicFilter, MqttQoS.AT_LEAST_ONCE, 0, groupId);
+        } catch (Exception e) {
+            logger.error(e.getMessage());
+            logger.error(e.getStackTrace().toString());
+        }
+
+    }
+
+    public SubscribeClient(String serverAddress, int serverPort, String topicFilter, int groupId) {
+
+        try {
+            this.blockClient = new BlockClient(serverAddress, serverPort);
+            this.topicFilter = topicFilter;
+            this.groupId = groupId;
+        } catch (ArrayIndexOutOfBoundsException e) {
+            logger.error("Not enough arguments");
+            System.exit(1);
+        } catch (Exception e) {
+            logger.error(e.getMessage());
+            System.exit(1);
+        }
+
+    }
+}

--- a/broke-sample/src/main/java/org/dsngroup/broke/SamplePublish.java
+++ b/broke-sample/src/main/java/org/dsngroup/broke/SamplePublish.java
@@ -43,8 +43,9 @@ public class SamplePublish {
             //    blockClient.publish("Foo", MqttQoS.AT_LEAST_ONCE, 0, "Bar");
             // }
 
-            while(System.in.read()!=0) {
+            while(true) {
                 blockClient.publish("Foo", MqttQoS.AT_LEAST_ONCE, 0, "Bar");
+                Thread.sleep(500);
             }
             // blockClient.disconnect();
 

--- a/broke-sample/src/main/java/org/dsngroup/broke/SampleSubscribe.java
+++ b/broke-sample/src/main/java/org/dsngroup/broke/SampleSubscribe.java
@@ -34,9 +34,9 @@ public class SampleSubscribe {
             blockClient.connect(0, 0);
             blockClient.subscribe("Foo", MqttQoS.AT_LEAST_ONCE, 0, 555);
             // blockClient.disconnect();
-            for (int i = 1; ; i++) {
+            while(true) {
                 if (System.in.read()!=0){
-                    blockClient.subscribe("Foo", MqttQoS.AT_LEAST_ONCE, 0, i);
+                    // Block
                 }
             }
         } catch (ArrayIndexOutOfBoundsException e) {

--- a/logging.properties
+++ b/logging.properties
@@ -1,0 +1,59 @@
+############################################################
+#  	Default Logging Configuration File
+#
+# You can use a different file by specifying a filename
+# with the java.util.logging.config.file system property.  
+# For example java -Djava.util.logging.config.file=myfile
+############################################################
+
+############################################################
+#  	Global properties
+############################################################
+
+# "handlers" specifies a comma separated list of log Handler 
+# classes.  These handlers will be installed during VM startup.
+# Note that these classes must be on the system classpath.
+# By default we only configure a ConsoleHandler, which will only
+# show messages at the INFO and above levels.
+handlers= java.util.logging.ConsoleHandler
+
+# To also add the FileHandler, use the following line instead.
+#handlers= java.util.logging.FileHandler, java.util.logging.ConsoleHandler
+
+# Default global logging level.
+# This specifies which kinds of events are logged across
+# all loggers.  For any given facility this global level
+# can be overriden by a facility specific level
+# Note that the ConsoleHandler also has a separate level
+# setting to limit messages printed to the console.
+.level= FINE
+
+############################################################
+# Handler specific properties.
+# Describes specific configuration info for Handlers.
+############################################################
+
+# default file output is in user's home directory.
+java.util.logging.FileHandler.pattern = %h/java%u.log
+java.util.logging.FileHandler.limit = 50000
+java.util.logging.FileHandler.count = 1
+java.util.logging.FileHandler.formatter = java.util.logging.XMLFormatter
+
+# Limit the message that are printed on the console to INFO and above.
+java.util.logging.ConsoleHandler.level = INFO
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+
+# Example to customize the SimpleFormatter output format 
+# to print one-line log message like this:
+#     <level>: <log message> [<date/time>]
+#
+# java.util.logging.SimpleFormatter.format=%4$s: %5$s [%1$tc]%n
+
+############################################################
+# Facility specific properties.
+# Provides extra control for each logger.
+############################################################
+
+# For example, set the com.xyz.foo logger to only log SEVERE
+# messages:
+com.xyz.foo.level = SEVERE


### PR DESCRIPTION
### RTT
1. RTT statistics contain RTT average, RTT standard deviations.
2. Consider the RTT as a normal one and add to the RTT history only when
it is in the range of 2 standard deviations of the history RTTs

### Group-ID-based publish
1. The subscribers in the same group are evaluated by an RTT-based score
currently.
2. The score is calculated by 1 divides by the subscriber's current
average RTT
3. When a PUBLISH message which matches this subscriber group's topic
filter, the subscriber with the **highest** score is chosen to publish
such PUBLISH message. (a.k.a. The subscriber with the lowest average RTT
is chosen.)

### Multi-Client
1. Over 100 publish/subscribe clients are created.
2. Performance measurement and correctness check of pub/sub are still undergoing.

### TODO list
1. Performance measurement and correctness check
2. Fake watermark mechanism on both server and client side.
3. Further score measurement considering both RTT and watermark.

@tz70s Please help take a look, thanks!