### PR TITLE
Flink Back Pressure

### DIFF
--- a/broke-client/src/main/java/org/dsngroup/broke/client/BlockClient.java
+++ b/broke-client/src/main/java/org/dsngroup/broke/client/BlockClient.java
@@ -25,6 +25,7 @@ import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.nio.NioSocketChannel;
 import org.dsngroup.broke.client.handler.callback.IMessageCallbackHandler;
 import org.dsngroup.broke.client.exception.ConnectLostException;
+import org.dsngroup.broke.client.storage.IPublishMessageQueue;
 import org.dsngroup.broke.client.util.ClientIdGenerator;
 import org.dsngroup.broke.client.util.PacketIdGenerator;
 import org.dsngroup.broke.client.handler.MqttMessageHandler;
@@ -60,15 +61,24 @@ public class BlockClient {
     private MqttMessageHandler mqttMessageHandler;
 
     /**
-     * Getter for client ID
+     * Getter for client ID.
      * */
     public String getClientId() {
         return clientId;
     }
 
     /**
-     * Send CONNECT to server
+     * Setter for publish message queue.
+     * @param publishMessageQueue The publish message queue.
+     * */
+    public void setPublishMessageQueue(IPublishMessageQueue publishMessageQueue) {
+        clientContext.getClientSession().setPublishMessageQueue(publishMessageQueue);
+    }
+
+    /**
+     * Send CONNECT to server.
      * @param qos qos option
+     * @param criticalOption Critical Option
      * */
     public void connect(MqttQoS qos, int criticalOption) throws Exception {
 

--- a/broke-client/src/main/java/org/dsngroup/broke/client/ClientContext.java
+++ b/broke-client/src/main/java/org/dsngroup/broke/client/ClientContext.java
@@ -20,22 +20,36 @@ import org.dsngroup.broke.client.metadata.ClientSession;
 import org.dsngroup.broke.client.storage.FakePublishMessageQueue;
 import org.dsngroup.broke.client.storage.PublishMessageQueue;
 
+/**
+ * The context that contains client's information.
+ * TODO: May be better to integrate with client session.
+ * */
 public class ClientContext {
 
     private ClientSession clientSession;
 
     private String clientId;
 
+    /**
+     * Getter for the client session.
+     * */
     public ClientSession getClientSession() {
         return clientSession;
     }
 
+    /**
+     * Getter for the client ID.
+     * */
     public String getClientId() {
         return clientId;
     }
 
+    /**
+     * Constructor of the client context.
+     * @param clientId Client ID.
+     * */
     public ClientContext(String clientId) {
         this.clientId = clientId;
-        clientSession = new ClientSession(clientId, new FakePublishMessageQueue(10, 0.3, 0.8));
+        clientSession = new ClientSession(clientId);
     }
 }

--- a/broke-client/src/main/java/org/dsngroup/broke/client/exception/ConnectLostException.java
+++ b/broke-client/src/main/java/org/dsngroup/broke/client/exception/ConnectLostException.java
@@ -16,8 +16,17 @@
 
 package org.dsngroup.broke.client.exception;
 
+/**
+ * Exception of connection lost.
+ * The exception can be thrown when the connection to the broker server lost.
+ * */
 public class ConnectLostException extends Exception {
-    public ConnectLostException(String message) {
-        super(message);
+
+    /**
+     * The constructor.
+     * @param cause Cause of the connection lost.
+     * */
+    public ConnectLostException(String cause) {
+        super(cause);
     }
 }

--- a/broke-client/src/main/java/org/dsngroup/broke/client/handler/MqttMessageHandler.java
+++ b/broke-client/src/main/java/org/dsngroup/broke/client/handler/MqttMessageHandler.java
@@ -30,7 +30,9 @@ import org.dsngroup.broke.client.handler.callback.IMessageCallbackHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
+/**
+ * Netty inbound channel handler for messages from the broker server.
+ * */
 public class MqttMessageHandler extends ChannelInboundHandlerAdapter {
 
     private static final Logger logger = LoggerFactory.getLogger(MqttMessageHandler.class);

--- a/broke-client/src/main/java/org/dsngroup/broke/client/handler/callback/DefaultMessageCallbackHandler.java
+++ b/broke-client/src/main/java/org/dsngroup/broke/client/handler/callback/DefaultMessageCallbackHandler.java
@@ -22,16 +22,27 @@ import org.slf4j.LoggerFactory;
 
 import java.nio.charset.StandardCharsets;
 
+/**
+ * Default message callback handler.
+ * Default behaviors of messageArrive() and connectionLost().
+ * */
 public class DefaultMessageCallbackHandler implements IMessageCallbackHandler {
 
     private static final Logger logger = LoggerFactory.getLogger(DefaultMessageCallbackHandler.class);
 
+    /**
+     * Print the publish message.
+     * @param mqttPublishMessage The incoming publish message.
+     * */
     @Override
     public void messageArrive(MqttPublishMessage mqttPublishMessage) {
         logger.info("topic: " + mqttPublishMessage.variableHeader().topicName() +
                 " payload: " + mqttPublishMessage.payload().toString(StandardCharsets.UTF_8));
     }
 
+    /**
+     * Log the connection lost error message.
+     * */
     @Override
     public void connectionLost(Throwable cause) {
         logger.error(cause.getMessage());

--- a/broke-client/src/main/java/org/dsngroup/broke/client/handler/callback/IMessageCallbackHandler.java
+++ b/broke-client/src/main/java/org/dsngroup/broke/client/handler/callback/IMessageCallbackHandler.java
@@ -18,7 +18,18 @@ package org.dsngroup.broke.client.handler.callback;
 
 import org.dsngroup.broke.protocol.MqttPublishMessage;
 
+/**
+ * Interface of the message callback handler.
+ * */
 public interface IMessageCallbackHandler {
+
+    /**
+     * Callback function called when a publish message arrived.
+     * */
     void messageArrive(MqttPublishMessage mqttPublishMessage);
+
+    /**
+     * Callback function called when the connection to the broker server lost.
+     * */
     void connectionLost(Throwable cause);
 }

--- a/broke-client/src/main/java/org/dsngroup/broke/client/handler/processor/ProtocolProcessor.java
+++ b/broke-client/src/main/java/org/dsngroup/broke/client/handler/processor/ProtocolProcessor.java
@@ -19,7 +19,6 @@ package org.dsngroup.broke.client.handler.processor;
 import io.netty.channel.ChannelHandlerContext;
 
 import org.dsngroup.broke.client.ClientContext;
-import org.dsngroup.broke.client.handler.callback.DefaultMessageCallbackHandler;
 import org.dsngroup.broke.client.handler.callback.IMessageCallbackHandler;
 import org.dsngroup.broke.client.exception.ConnectLostException;
 import org.dsngroup.broke.client.metadata.ClientSession;
@@ -29,9 +28,11 @@ import org.slf4j.LoggerFactory;
 
 import java.nio.charset.StandardCharsets;
 
+/**
+ * The protocol processor of the client.
+ * Process inbound messages from the broker.
+ * */
 public class ProtocolProcessor {
-
-    private ClientContext clientContext;
 
     private ClientSession clientSession;
 
@@ -39,6 +40,10 @@ public class ProtocolProcessor {
 
     private IMessageCallbackHandler messageCallbackHandler;
 
+    /**
+     * Setter for the message callback handler.
+     * @param messageCallbackHandler User-defined message callback handler.
+     * */
     public void setMessageCallbackHandler(IMessageCallbackHandler messageCallbackHandler) {
         this.messageCallbackHandler = messageCallbackHandler;
     }
@@ -64,8 +69,6 @@ public class ProtocolProcessor {
      * @param mqttPublishMessage PUBLISH message from broker
      * */
     public void processPublish(ChannelHandlerContext ctx, MqttPublishMessage mqttPublishMessage) throws Exception {
-        clientSession.getPublishMessageQueue()
-                .putMessage(mqttPublishMessage.payload().toString(StandardCharsets.UTF_8));
         messageCallbackHandler.messageArrive(mqttPublishMessage);
 
         MqttFixedHeader mqttFixedHeader =
@@ -121,7 +124,6 @@ public class ProtocolProcessor {
     }
 
     public ProtocolProcessor(ClientContext clientContext) {
-        this.clientContext = clientContext;
         this.clientSession = clientContext.getClientSession();
     }
 }

--- a/broke-client/src/main/java/org/dsngroup/broke/client/storage/FakePublishMessageQueue.java
+++ b/broke-client/src/main/java/org/dsngroup/broke/client/storage/FakePublishMessageQueue.java
@@ -41,6 +41,26 @@ public class FakePublishMessageQueue implements IPublishMessageQueue {
     private static final Logger logger = LoggerFactory.getLogger(FakePublishMessageQueue.class);
 
     @Override
+    public int getMaxSize() {
+        return maxSize;
+    }
+
+    @Override
+    public double getLowWaterMark() {
+        return lowWaterMark;
+    }
+
+    @Override
+    public double getHighWaterMark() {
+        return highWaterMark;
+    }
+
+    @Override
+    public int getCapacity() {
+        return 0;
+    }
+
+    @Override
     public boolean isBackPressured() {
         return isBackPressured;
     }
@@ -60,12 +80,18 @@ public class FakePublishMessageQueue implements IPublishMessageQueue {
         return null;
     }
 
+    /**
+     * Constructor of the fake publish message queue.
+     * */
     public FakePublishMessageQueue(int maxSize, double lowWaterMark, double highWaterMark) {
         this.maxSize = maxSize;
         this.lowWaterMark = lowWaterMark;
         this.highWaterMark = highWaterMark;
     }
 
+    /**
+     * Set the back-pressure status to false after a while.
+     * */
     class BackPressureSetterThread extends Thread {
 
         private int execTime;
@@ -79,8 +105,7 @@ public class FakePublishMessageQueue implements IPublishMessageQueue {
                 // TODO: debug
                 logger.info("cancel back pressure");
             } catch (Exception e) {
-                // TODO: delete this
-                e.printStackTrace();
+                logger.error("Back-pressure setter thread: " + e.getMessage());
             }
         }
 

--- a/broke-client/src/main/java/org/dsngroup/broke/client/storage/IPublishMessageQueue.java
+++ b/broke-client/src/main/java/org/dsngroup/broke/client/storage/IPublishMessageQueue.java
@@ -16,8 +16,44 @@
 
 package org.dsngroup.broke.client.storage;
 
+/**
+ * Interface for a publish message queue.
+ * */
 public interface IPublishMessageQueue {
+
+    /**
+     * Getter for the back-pressure status of the queue.
+     * */
     boolean isBackPressured();
+
+    /**
+     * Put the message into this queue.
+     * @param message Message to put into the queue.
+     * */
     void putMessage(String message);
+
+    /**
+     * Getter for the message at the front of the queue (First-In-First-Out).
+     * */
     String getMessage();
+
+    /**
+     * Getter for the max number of messages this queue can store.
+     * */
+    int getMaxSize();
+
+    /**
+     * Getter for the low watermark percentage in double.
+     * */
+    double getLowWaterMark();
+
+    /**
+     * Getter for the high watermark percentage.
+     * */
+    double getHighWaterMark();
+
+    /**
+     * Getter for the current capacity of the queue.
+     * */
+    int getCapacity();
 }

--- a/broke-flink-sample/src/main/java/org/dsngroup/broke/util/PublishMessageQueueMonitor.java
+++ b/broke-flink-sample/src/main/java/org/dsngroup/broke/util/PublishMessageQueueMonitor.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2017 original authors and authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dsngroup.broke.util;
+
+import org.apache.flink.api.common.functions.AbstractRichFunction;
+import org.dsngroup.broke.client.storage.IPublishMessageQueue;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Serializable;
+
+/**
+ * A thread that reports the status of publish message queue periodically.
+ * E.g. Current back-pressure status, queue capacity and default max size of the queue.
+ * */
+public class PublishMessageQueueMonitor extends AbstractRichFunction implements Runnable, Serializable {
+
+    public static final Logger logger = LoggerFactory.getLogger(PublishMessageQueueMonitor.class);
+
+    IPublishMessageQueue publishMessageQueue;
+
+    @Override
+    public void run() {
+        while(true) {
+            logger.info("Back pressure status: " + publishMessageQueue.isBackPressured() +
+                    " current capacity: " + publishMessageQueue.getCapacity() +
+                    " max capacity: " + publishMessageQueue.getMaxSize());
+            try {
+                Thread.sleep(3000);
+            } catch (Exception e) {
+                logger.error("Monitor thread failed: " + e.getMessage());
+            }
+        }
+    }
+
+    /**
+     * Constructor of the queue monitor.
+     * Set the publish message queue to monitor.
+     * @param publishMessageQueue Publish message queue to monitor.
+     * */
+    public PublishMessageQueueMonitor(IPublishMessageQueue publishMessageQueue) {
+        this.publishMessageQueue = publishMessageQueue;
+    }
+}
+

--- a/broke-sample/src/main/java/org/dsngroup/broke/MultiClient.java
+++ b/broke-sample/src/main/java/org/dsngroup/broke/MultiClient.java
@@ -35,7 +35,7 @@ public class MultiClient {
             String serverAddress = args[0];
             int serverPort = Integer.parseInt(args[1]);
 
-            int numOfClients = 100;
+            int numOfClients = Integer.parseInt(args[2]);
 
             PublishClient[] publishClients = new PublishClient[numOfClients];
             SubscribeClient[] subscribeClients = new SubscribeClient[numOfClients];
@@ -45,10 +45,10 @@ public class MultiClient {
             int groupId = 1; // Subscribe group ID
 
             // Initialize subscribe clients
-            for (int i = 0; i < subscribeClients.length; i++) {
-                subscribeClients[i] = new SubscribeClient(serverAddress, serverPort, topic, groupId);
-                subscribeClients[i].start();
-            }
+            // for (int i = 0; i < subscribeClients.length; i++) {
+            //     subscribeClients[i] = new SubscribeClient(serverAddress, serverPort, topic, groupId);
+            //     subscribeClients[i].start();
+            // }
 
             // Initialize publish clients
             for (int i = 0; i < publishClients.length; i++) {
@@ -89,8 +89,13 @@ public class MultiClient {
             try {
                 blockClient.connect(MqttQoS.AT_LEAST_ONCE, 0);
                 blockClient.setMessageCallbackHandler(new MessageCallbackHandler());
+                String payload = "During the 2012–13 season, Curry set the NBA record for three-pointers made in a " +
+                        "regular season with 272. He surpassed that record in 2015 with 286, and again in 2016 with " +
+                        "402. During the 2013–14 season, he and teammate Klay Thompson were nicknamed the Splash " +
+                        "Brothers en route to setting the NBA record for combined three-pointers in a season with " +
+                        "484, a record they broke the following season (525) and again in the 2015–16 season (678).";
                 while (true) {
-                    blockClient.publish(topic, MqttQoS.AT_LEAST_ONCE, 0, "Foo");
+                    blockClient.publish(topic, MqttQoS.AT_LEAST_ONCE, 0, payload);
                     Thread.sleep(sleepInterval);
                 }
             } catch (Exception e) {

--- a/tools/docker-compose.yml
+++ b/tools/docker-compose.yml
@@ -1,0 +1,46 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+# Set the FLINK_DOCKER_IMAGE_NAME environment variable to override the image name to use
+
+version: "2.2"
+services:
+  jobmanager:
+    image: ${FLINK_DOCKER_IMAGE_NAME:-flink}
+    expose:
+      - "6123"
+    ports:
+      - "8081:8081"
+    command: jobmanager
+    environment:
+      - JOB_MANAGER_RPC_ADDRESS=jobmanager
+
+  taskmanager:
+    image: ${FLINK_DOCKER_IMAGE_NAME:-flink}
+    expose:
+      - "6121"
+      - "6122"
+    depends_on:
+      - jobmanager
+    command: taskmanager
+    links:
+      - "jobmanager:jobmanager"
+    environment:
+      - JOB_MANAGER_RPC_ADDRESS=jobmanager
+    cpus: 0.1
+        


### PR DESCRIPTION
### Queue-based back-pressure mechanism in ```BrokeSource```.
1. The ```BrokeSource``` maintains a ```publishMessageQueue``` which stores all incoming publish messages. 
2. The ```BrokeSource``` continuously polls from the ```publishMessageQueue``` and emits the messages to the topology.

Finally, I decided to implement the queue-based back-pressure because Flink's metrics are difficult to form a general back-pressure mechanism.

@tz70s Please help take a look, thanks!